### PR TITLE
Add integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,24 @@
+name: Integration tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+      - main
+
+jobs:
+  run-integration-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run integration tests with docker compose
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cd integration-tests
+          docker compose up --build --abort-on-container-exit
+

--- a/README.md
+++ b/README.md
@@ -39,6 +39,18 @@ Inside the dev shell you can build gh-get by running `go build`.
 Make sure you have a Go toolchain installed in your path that matches the version defined in [go.mod](go.mod).
 Build gh-get by running `go build`.
 
+## Testing
+
+The project contains two sorts of tests:
+
+- Unit tests written in go testing individual functions. You can execute these by running `go test ./...`
+- Integration tests running inside a docker container. You can execute these by running `cd integration-tests && sudo GH_TOKEN=<personal access token> docker compose up --build --abort-on-container-exit`.
+
+To get a personal access token, you can either look the one currently used by your GitHub CLI installation up in `~/.config/gh/hosts.yaml` or generate a new one in your [GitHub settings](https://github.com/settings/tokens).
+
+> [!IMPORTANT]
+> Before submitting pull requests make sure to run all tests and add new test cases for the functionality you've added.
+
 ## License
 
 Code is under the [Apache Licence v2](https://www.apache.org/licenses/LICENSE-2.0.txt).

--- a/integration-tests/Dockerfile
+++ b/integration-tests/Dockerfile
@@ -1,0 +1,21 @@
+# Stage 1: Build gh-get
+FROM golang:1.21-alpine AS builder
+
+RUN apk add --no-cache git gcc musl-dev
+
+COPY . /workspace/gh-get
+
+WORKDIR /workspace/gh-get
+RUN go build
+
+# Stage 2: Test Image
+FROM maniator/gh:latest
+
+COPY --from=builder /workspace/gh-get /workspace/gh-get
+
+COPY /integration-tests/tests.sh /workspace/tests.sh
+
+RUN chmod +x /workspace/tests.sh
+
+ENTRYPOINT ["/bin/sh", "/workspace/tests.sh"]
+

--- a/integration-tests/docker-compose.yaml
+++ b/integration-tests/docker-compose.yaml
@@ -1,0 +1,7 @@
+services:
+  test-container:
+    build:
+      context: ..
+      dockerfile: integration-tests/Dockerfile
+    environment:
+      - GH_TOKEN=${GH_TOKEN}

--- a/integration-tests/tests.sh
+++ b/integration-tests/tests.sh
@@ -1,0 +1,34 @@
+!#/bin/sh
+
+echo "Installing gh-get"
+cd /workspace/gh-get
+gh extension install .
+
+test() {
+	local repository_definition="$1"
+	local expected_path="$2"
+
+	echo "gh get $repository_definition"
+	gh get "$repository_definition"
+
+	if [[ -d "$expected_path" ]]; then
+		echo "SUCCESS"
+		echo ""
+		rm -rf "$expected_path"
+	else
+		echo "FAILURE"
+		exit 1
+	fi
+}
+
+test "britter/gh-get" "/root/github/britter/gh-get"
+test "https://github.com/britter/gh-get" "/root/github/britter/gh-get"
+test "https://github.com/britter/gh-get.git" "/root/github/britter/gh-get"
+
+export GH_GET_FOLDER=src
+test "britter/gh-get" "/root/src/britter/gh-get"
+unset GH_GET_FOLDER
+
+export GH_GET_ROOT=/repositories
+test "britter/gh-get" "/repositories/britter/gh-get"
+


### PR DESCRIPTION
Integration tests based on docker compose and a test shell script. A custom multi-stage docker image is used to build the lastest version of gh-get. Then an image that has GitHub CLI preinstalled is used for running the tests. The test script first installs the prebuild gh-get binary. For this to work, GitHub CLI needs to be authenticated. This requires passing the GH_TOKEN environment variable into the test docker container. The tests cover some of the happy path scenarios.