### PR TITLE
feat: accept any GitHub URL as repository argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Clone progress is now streamed to the terminal in real time using go-git,
   resolving the hang on large repositories (#11)
+- The repository argument now accepts any GitHub URL, including URLs pointing
+  to branches, tags, commits, files, pull requests, and issues
+  (e.g. `https://github.com/owner/repo/tree/my-branch`) (#15)
 
 ### Changed
 

--- a/pkg/github/repository.go
+++ b/pkg/github/repository.go
@@ -16,7 +16,7 @@ func Parse(definition string) (Repository, error) {
 	definition = strings.TrimSuffix(definition, ".git")
 
 	parts := strings.Split(definition, "/")
-	if len(parts) != 2 {
+	if len(parts) < 2 {
 		return Repository{}, fmt.Errorf("Invalid repository definition: %s", definition)
 	}
 

--- a/pkg/github/repository_test.go
+++ b/pkg/github/repository_test.go
@@ -16,6 +16,13 @@ func TestParse(t *testing.T) {
 		{"https://github.com/owner/name", "owner", "name", false},
 		{"https://github.com/owner/name.git", "owner", "name", false},
 		{"git@github.com:owner/name.git", "owner", "name", false},
+		{"https://github.com/owner/name/tree/main", "owner", "name", false},
+		{"https://github.com/owner/name/tree/feature/my-feature", "owner", "name", false},
+		{"https://github.com/owner/name/tree/v1.2.3", "owner", "name", false},
+		{"https://github.com/owner/name/commit/abc1234", "owner", "name", false},
+		{"https://github.com/owner/name/blob/main/README.md", "owner", "name", false},
+		{"https://github.com/owner/name/pull/42", "owner", "name", false},
+		{"https://github.com/owner/name/issues/42", "owner", "name", false},
 
 		// Invalid cases
 		{"https://github.com/invalidinput", "", "", true}, // Missing /


### PR DESCRIPTION
The parser now extracts owner and repo from any GitHub URL, so users
can paste URLs pointing to branches, tags, commits, files, pull requests,
or issues without trimming them first.

Closes #15.
