### PR TITLE
feat: show simple clone progress and print destination path to stdout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `--verbose` flag to print additional diagnostic output to stderr throughout
   the clone flow (repository info, fork decisions, remote setup)
+- Print the clone destination path to stdout at the end of every clone operation for easy piping
+
+### Changed
+
+- Git transfer progress is now hidden by default; use `--verbose` to stream it
 
 ## [2.3.0] - 2026-05-04
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,35 @@ Example:
 > [!TIP]
 > gh-get also accepts full GitHub URLs like `https://github.com/britter/gh-get` as well as URLs pointing to branches, tags, commits, files, pull requests, or issues — anything you can copy from your browser.
 
+### Changing into the cloned directory
+
+gh-get prints the clone destination to stdout, which makes it easy to combine with `cd`:
+
+```sh
+cd "$(gh get britter/gh-get)"
+```
+
+Since `cd` doesn't work inside a subshell, you may want to add a wrapper function to your shell config that does this automatically:
+
+**bash / zsh**
+
+```sh
+get() {
+  local dest
+  dest="$(gh get "$@")" && cd "$dest"
+}
+```
+
+**fish**
+
+```fish
+function get
+  set dest (gh get $argv) && cd $dest
+end
+```
+
+After adding the function, `get britter/gh-get` will clone the repository and drop you straight into the directory.
+
 ### Forking
 
 When you don't have write access to a repository, gh-get will ask whether you want to fork it first. If you answer yes, the fork is created under your account and cloned into `$HOME/github/$YOUR_USERNAME/$REPO`.

--- a/internal/clone/clone.go
+++ b/internal/clone/clone.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"time"
 
 	"github.com/britter/gh-get/internal/github"
 	"github.com/cli/go-gh/v2/pkg/auth"
@@ -19,8 +20,7 @@ func Clone(target github.CloneTarget, clonePath string, diag io.Writer) error {
 	cloneURL := "https://github.com/" + target.Repository.Owner + "/" + target.Repository.Name + ".git"
 
 	opts := &git.CloneOptions{
-		URL:      cloneURL,
-		Progress: os.Stderr,
+		URL: cloneURL,
 	}
 
 	token, _ := auth.TokenForHost("github.com")
@@ -33,10 +33,38 @@ func Clone(target github.CloneTarget, clonePath string, diag io.Writer) error {
 	}
 
 	fmt.Fprintf(diag, "Cloning %s into %s\n", cloneURL, clonePath)
-	r, err := git.PlainClone(clonePath, false, opts)
+
+	var r *git.Repository
+	var err error
+
+	if diag != io.Discard {
+		opts.Progress = os.Stderr
+		r, err = git.PlainClone(clonePath, false, opts)
+	} else {
+		fmt.Fprintf(os.Stderr, "Cloning into %s", clonePath)
+		stop := make(chan struct{})
+		go func() {
+			ticker := time.NewTicker(3 * time.Second)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-ticker.C:
+					fmt.Fprint(os.Stderr, ".")
+				case <-stop:
+					return
+				}
+			}
+		}()
+		r, err = git.PlainClone(clonePath, false, opts)
+		close(stop)
+		fmt.Fprintln(os.Stderr, " done")
+	}
+
 	if err != nil {
 		return err
 	}
+
+	fmt.Fprintln(os.Stdout, clonePath)
 
 	if target.Fork != nil {
 		fmt.Fprintf(diag, "Renaming origin to upstream, adding fork %s/%s as origin\n", target.Fork.Owner, target.Fork.Name)


### PR DESCRIPTION
- Git transfer progress is now hidden by default; pass `--verbose` to stream it
- A simple animated indicator (dots) is shown while cloning instead
- The clone destination is printed to stdout on completion for easy piping: `cd "$(gh get owner/repo)"`
- Documents wrapper functions for bash/zsh and fish that `cd` automatically after cloning