### PR TITLE
fix: clone original when user declines to fork

### DIFF
--- a/internal/github/fork.go
+++ b/internal/github/fork.go
@@ -1,14 +1,10 @@
 package github
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"os"
 )
-
-// ErrCancelled is returned when the user declines to fork.
-var ErrCancelled = errors.New("cancelled")
 
 // Prompter can prompt the user for confirmation.
 type Prompter interface {
@@ -47,8 +43,6 @@ type CloneTarget struct {
 // Repository as upstream and add Fork as origin.
 //
 // diag receives verbose diagnostic messages; pass io.Discard to suppress them.
-//
-// Returns ErrCancelled if the user declines to fork.
 func ResolveCloneTarget(owner, name string, fork *bool, client Client, prompter Prompter, diag io.Writer) (CloneTarget, error) {
 	fmt.Fprintf(diag, "Fetching repository info for %s/%s\n", owner, name)
 	info, err := client.RepoInfo(owner, name)
@@ -79,7 +73,8 @@ func ResolveCloneTarget(owner, name string, fork *bool, client Client, prompter 
 			return CloneTarget{}, err
 		}
 		if !answer {
-			return CloneTarget{}, ErrCancelled
+			fmt.Fprintf(diag, "User declined fork, cloning original\n")
+			return CloneTarget{Repository: Repository{owner, name}}, nil
 		}
 		return forkRepo(owner, name, client)
 	}

--- a/internal/github/fork_test.go
+++ b/internal/github/fork_test.go
@@ -81,13 +81,13 @@ func TestResolveCloneTarget(t *testing.T) {
 			expectedTarget: CloneTarget{Repository: Repository{"owner", "repo"}, Fork: repoPtr("me", "new-name")},
 		},
 		{
-			name: "no write access, forking allowed, user says no: cancelled",
+			name: "no write access, forking allowed, user says no: clone original",
 			fork: nil,
 			client: &fakeClient{
 				info: RepoInfo{AllowForking: true, HasPushAccess: false},
 			},
-			prompter:    &fakePrompter{answer: false},
-			expectedErr: ErrCancelled,
+			prompter:       &fakePrompter{answer: false},
+			expectedTarget: CloneTarget{Repository: Repository{"owner", "repo"}},
 		},
 		{
 			name: "no write access, forking disabled: clone original with warning",
@@ -196,11 +196,7 @@ func TestResolveCloneTarget(t *testing.T) {
 				if err == nil {
 					t.Fatalf("expected error %q, got nil", tt.expectedErr)
 				}
-				if tt.expectedErr == ErrCancelled {
-					if !errors.Is(err, ErrCancelled) {
-						t.Errorf("expected ErrCancelled, got %v", err)
-					}
-				} else if err.Error() != tt.expectedErr.Error() {
+				if err.Error() != tt.expectedErr.Error() {
 					t.Errorf("expected error %q, got %q", tt.expectedErr, err)
 				}
 				return

--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -55,9 +54,6 @@ func run() error {
 	p := prompter.New(os.Stdin, os.Stdout, os.Stderr)
 	target, err := github.ResolveCloneTarget(repository.Owner, repository.Name, fork, client, p, diag)
 	if err != nil {
-		if errors.Is(err, github.ErrCancelled) {
-			return nil
-		}
 		return err
 	}
 


### PR DESCRIPTION
Declining the fork prompt now clones the original repository into `<owner>/<repo>` instead of aborting the clone.

Fixes #83