### PR TITLE
feat: handle existing clones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Re-running `gh get` on an already-cloned repository now prompts to update the
   existing clone instead of failing. On confirmation, gh-get fetches upstream and
-  fast-forwards the current branch, reconfiguring remotes if a fork is newly
-  requested. Local changes and diverged branches are left untouched (#5)
+  fast-forwards the current branch. Before rewriting remotes for a newly
+  requested fork it asks for confirmation. Local changes and diverged branches
+  are left untouched (#5)
 
 ## [2.5.0] - 2026-05-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Re-running `gh get` on an already-cloned repository now prompts to update the
+  existing clone instead of failing. On confirmation, gh-get fetches upstream and
+  fast-forwards the current branch, reconfiguring remotes if a fork is newly
+  requested. Local changes and diverged branches are left untouched (#5)
+
 ## [2.5.0] - 2026-05-05
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -58,6 +58,15 @@ You can also pass `--fork` to skip the prompt and always fork:
 
 If the repository does not allow forking, the original is cloned and a warning is printed.
 
+### Updating an existing clone
+
+If you run `gh get` for a repository you already cloned, gh-get asks whether to
+update the existing clone instead of failing. If you agree, it fetches upstream
+and fast-forwards the current branch (local changes or a diverged branch are
+left untouched). When the existing clone points at the original but you now ask
+to fork, the fork is created and the remotes are reconfigured (`origin` → your
+fork, `upstream` → the original).
+
 ## Configuration
 
 There are two environment variables that control the location gh-get clones repositories to:

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ If you run `gh get` for a repository you already cloned, gh-get asks whether to
 update the existing clone instead of failing. If you agree, it fetches upstream
 and fast-forwards the current branch (local changes or a diverged branch are
 left untouched). When the existing clone points at the original but you now ask
-to fork, the fork is created and the remotes are reconfigured (`origin` → your
-fork, `upstream` → the original).
+to fork, the fork is created and — after a confirmation prompt — the remotes are
+reconfigured (`origin` → your fork, `upstream` → the original).
 
 ## Configuration
 

--- a/internal/clone/clone.go
+++ b/internal/clone/clone.go
@@ -4,12 +4,15 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
+	"strings"
 	"time"
 
 	"github.com/britter/gh-get/internal/github"
 	"github.com/cli/go-gh/v2/pkg/auth"
 	git "github.com/go-git/go-git/v5"
 	gitconfig "github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing/transport"
 	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
 )
 
@@ -20,16 +23,8 @@ func Clone(target github.CloneTarget, clonePath string, diag io.Writer) error {
 	cloneURL := "https://github.com/" + target.Repository.Owner + "/" + target.Repository.Name + ".git"
 
 	opts := &git.CloneOptions{
-		URL: cloneURL,
-	}
-
-	token, _ := auth.TokenForHost("github.com")
-	if token != "" {
-		fmt.Fprintln(diag, "Using GitHub token for authentication")
-		opts.Auth = &githttp.BasicAuth{
-			Username: "x-access-token",
-			Password: token,
-		}
+		URL:  cloneURL,
+		Auth: authMethod(diag),
 	}
 
 	fmt.Fprintf(diag, "Cloning %s into %s\n", cloneURL, clonePath)
@@ -71,6 +66,82 @@ func Clone(target github.CloneTarget, clonePath string, diag io.Writer) error {
 		return setupForkRemotes(r, target.Fork, diag)
 	}
 	return nil
+}
+
+// Exists reports whether path is an existing git repository.
+func Exists(path string) bool {
+	_, err := git.PlainOpen(path)
+	return err == nil
+}
+
+// Sync updates an existing clone at clonePath to match target and fast-forwards
+// the current branch to upstream. If target.Fork is set and the clone currently
+// points origin at the original, the remotes are reconfigured (origin ->
+// upstream, fork -> origin). Local work is never clobbered: a diverged branch or
+// dirty worktree is reported and skipped.
+func Sync(target github.CloneTarget, clonePath string, diag io.Writer) error {
+	r, err := git.PlainOpen(clonePath)
+	if err != nil {
+		return err
+	}
+
+	originalURL := "https://github.com/" + target.Repository.Owner + "/" + target.Repository.Name + ".git"
+
+	if target.Fork != nil {
+		origin, err := r.Remote("origin")
+		if err != nil {
+			return err
+		}
+		if clonesOriginal(origin, originalURL) {
+			fmt.Fprintf(diag, "Existing clone points at the original; reconfiguring remotes for fork %s/%s\n", target.Fork.Owner, target.Fork.Name)
+			if err := setupForkRemotes(r, target.Fork, diag); err != nil {
+				return err
+			}
+		}
+	}
+
+	// After reconfiguration the original lives in upstream; otherwise it's origin.
+	remote := "origin"
+	if _, err := r.Remote("upstream"); err == nil {
+		remote = "upstream"
+	}
+
+	fmt.Fprintf(diag, "Synchronizing with %s\n", remote)
+	w, err := r.Worktree()
+	if err != nil {
+		return err
+	}
+	err = w.Pull(&git.PullOptions{RemoteName: remote, Auth: authMethod(diag)})
+	switch err {
+	case nil, git.NoErrAlreadyUpToDate:
+		// up to date or fast-forwarded
+	case git.ErrNonFastForwardUpdate:
+		fmt.Fprintln(os.Stderr, "Local branch has diverged from upstream, skipping fast-forward.")
+	default:
+		if strings.Contains(err.Error(), "worktree contains unstaged changes") {
+			fmt.Fprintln(os.Stderr, "Working tree has local changes, skipping fast-forward.")
+		} else {
+			return err
+		}
+	}
+
+	fmt.Fprintln(os.Stdout, clonePath)
+	return nil
+}
+
+// clonesOriginal reports whether the origin remote points at the original repo.
+func clonesOriginal(origin *git.Remote, originalURL string) bool {
+	return slices.Contains(origin.Config().URLs, originalURL)
+}
+
+// authMethod returns GitHub token auth if a token is available, else nil.
+func authMethod(diag io.Writer) transport.AuthMethod {
+	token, _ := auth.TokenForHost("github.com")
+	if token == "" {
+		return nil
+	}
+	fmt.Fprintln(diag, "Using GitHub token for authentication")
+	return &githttp.BasicAuth{Username: "x-access-token", Password: token}
 }
 
 func setupForkRemotes(r *git.Repository, fork *github.Repository, diag io.Writer) error {

--- a/internal/clone/clone.go
+++ b/internal/clone/clone.go
@@ -79,7 +79,7 @@ func Exists(path string) bool {
 // points origin at the original, the remotes are reconfigured (origin ->
 // upstream, fork -> origin). Local work is never clobbered: a diverged branch or
 // dirty worktree is reported and skipped.
-func Sync(target github.CloneTarget, clonePath string, diag io.Writer) error {
+func Sync(target github.CloneTarget, clonePath string, p github.Prompter, diag io.Writer) error {
 	r, err := git.PlainOpen(clonePath)
 	if err != nil {
 		return err
@@ -93,9 +93,18 @@ func Sync(target github.CloneTarget, clonePath string, diag io.Writer) error {
 			return err
 		}
 		if clonesOriginal(origin, originalURL) {
-			fmt.Fprintf(diag, "Existing clone points at the original; reconfiguring remotes for fork %s/%s\n", target.Fork.Owner, target.Fork.Name)
-			if err := setupForkRemotes(r, target.Fork, diag); err != nil {
+			ok, err := p.Confirm(fmt.Sprintf("Reconfigure remotes (origin -> %s/%s, upstream -> %s/%s)?",
+				target.Fork.Owner, target.Fork.Name, target.Repository.Owner, target.Repository.Name), true)
+			if err != nil {
 				return err
+			}
+			if !ok {
+				fmt.Fprintln(os.Stderr, "Leaving remotes unchanged; fetching upstream only.")
+			} else {
+				fmt.Fprintf(diag, "Reconfiguring remotes for fork %s/%s\n", target.Fork.Owner, target.Fork.Name)
+				if err := setupForkRemotes(r, target.Fork, diag); err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/internal/clone/clone_test.go
+++ b/internal/clone/clone_test.go
@@ -1,0 +1,91 @@
+package clone
+
+import (
+	"io"
+	"testing"
+
+	"github.com/britter/gh-get/internal/github"
+	git "github.com/go-git/go-git/v5"
+	gitconfig "github.com/go-git/go-git/v5/config"
+)
+
+func TestExists(t *testing.T) {
+	dir := t.TempDir()
+	if Exists(dir) {
+		t.Fatalf("empty dir should not be reported as a repo")
+	}
+	if _, err := git.PlainInit(dir, false); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	if !Exists(dir) {
+		t.Fatalf("initialized repo should be reported as existing")
+	}
+}
+
+// When the existing clone points origin at the original and a fork is requested,
+// Sync reconfigures remotes: origin -> fork, upstream -> original.
+func TestSyncReconfiguresRemotesForFork(t *testing.T) {
+	dir := t.TempDir()
+	r, err := git.PlainInit(dir, false)
+	if err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	originalURL := "https://github.com/owner/repo.git"
+	if _, err := r.CreateRemote(&gitconfig.RemoteConfig{Name: "origin", URLs: []string{originalURL}}); err != nil {
+		t.Fatalf("create origin: %v", err)
+	}
+
+	target := github.CloneTarget{
+		Repository: github.Repository{Owner: "owner", Name: "repo"},
+		Fork:       &github.Repository{Owner: "me", Name: "repo"},
+	}
+	// Pull will fail (no worktree/commits/network), but remote reconfiguration
+	// happens first and is what we assert. Ignore the sync error here.
+	_ = Sync(target, dir, io.Discard)
+
+	upstream, err := r.Remote("upstream")
+	if err != nil {
+		t.Fatalf("expected upstream remote: %v", err)
+	}
+	if got := upstream.Config().URLs[0]; got != originalURL {
+		t.Errorf("upstream URL = %q, want %q", got, originalURL)
+	}
+	origin, err := r.Remote("origin")
+	if err != nil {
+		t.Fatalf("expected origin remote: %v", err)
+	}
+	forkURL := "https://github.com/me/repo.git"
+	if got := origin.Config().URLs[0]; got != forkURL {
+		t.Errorf("origin URL = %q, want %q", got, forkURL)
+	}
+}
+
+// When origin already points at a fork (not the original), remotes are left alone.
+func TestSyncLeavesForkCloneRemotesAlone(t *testing.T) {
+	dir := t.TempDir()
+	r, err := git.PlainInit(dir, false)
+	if err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	forkURL := "https://github.com/me/repo.git"
+	if _, err := r.CreateRemote(&gitconfig.RemoteConfig{Name: "origin", URLs: []string{forkURL}}); err != nil {
+		t.Fatalf("create origin: %v", err)
+	}
+
+	target := github.CloneTarget{
+		Repository: github.Repository{Owner: "owner", Name: "repo"},
+		Fork:       &github.Repository{Owner: "me", Name: "repo"},
+	}
+	_ = Sync(target, dir, io.Discard)
+
+	if _, err := r.Remote("upstream"); err == nil {
+		t.Errorf("upstream remote should not be created when origin already a fork")
+	}
+	origin, err := r.Remote("origin")
+	if err != nil {
+		t.Fatalf("origin remote missing: %v", err)
+	}
+	if got := origin.Config().URLs[0]; got != forkURL {
+		t.Errorf("origin URL changed to %q, want %q", got, forkURL)
+	}
+}

--- a/internal/clone/clone_test.go
+++ b/internal/clone/clone_test.go
@@ -9,6 +9,10 @@ import (
 	gitconfig "github.com/go-git/go-git/v5/config"
 )
 
+type fakePrompter struct{ answer bool }
+
+func (f fakePrompter) Confirm(_ string, _ bool) (bool, error) { return f.answer, nil }
+
 func TestExists(t *testing.T) {
 	dir := t.TempDir()
 	if Exists(dir) {
@@ -41,7 +45,7 @@ func TestSyncReconfiguresRemotesForFork(t *testing.T) {
 	}
 	// Pull will fail (no worktree/commits/network), but remote reconfiguration
 	// happens first and is what we assert. Ignore the sync error here.
-	_ = Sync(target, dir, io.Discard)
+	_ = Sync(target, dir, fakePrompter{answer: true}, io.Discard)
 
 	upstream, err := r.Remote("upstream")
 	if err != nil {
@@ -57,6 +61,36 @@ func TestSyncReconfiguresRemotesForFork(t *testing.T) {
 	forkURL := "https://github.com/me/repo.git"
 	if got := origin.Config().URLs[0]; got != forkURL {
 		t.Errorf("origin URL = %q, want %q", got, forkURL)
+	}
+}
+
+// When the user declines the reconfigure prompt, remotes are left untouched.
+func TestSyncDeclineLeavesRemotesUntouched(t *testing.T) {
+	dir := t.TempDir()
+	r, err := git.PlainInit(dir, false)
+	if err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	originalURL := "https://github.com/owner/repo.git"
+	if _, err := r.CreateRemote(&gitconfig.RemoteConfig{Name: "origin", URLs: []string{originalURL}}); err != nil {
+		t.Fatalf("create origin: %v", err)
+	}
+
+	target := github.CloneTarget{
+		Repository: github.Repository{Owner: "owner", Name: "repo"},
+		Fork:       &github.Repository{Owner: "me", Name: "repo"},
+	}
+	_ = Sync(target, dir, fakePrompter{answer: false}, io.Discard)
+
+	if _, err := r.Remote("upstream"); err == nil {
+		t.Errorf("upstream remote should not be created when user declines")
+	}
+	origin, err := r.Remote("origin")
+	if err != nil {
+		t.Fatalf("origin remote missing: %v", err)
+	}
+	if got := origin.Config().URLs[0]; got != originalURL {
+		t.Errorf("origin URL changed to %q, want %q", got, originalURL)
 	}
 }
 
@@ -76,7 +110,7 @@ func TestSyncLeavesForkCloneRemotesAlone(t *testing.T) {
 		Repository: github.Repository{Owner: "owner", Name: "repo"},
 		Fork:       &github.Repository{Owner: "me", Name: "repo"},
 	}
-	_ = Sync(target, dir, io.Discard)
+	_ = Sync(target, dir, fakePrompter{answer: true}, io.Discard)
 
 	if _, err := r.Remote("upstream"); err == nil {
 		t.Errorf("upstream remote should not be created when origin already a fork")

--- a/main.go
+++ b/main.go
@@ -77,7 +77,7 @@ func run() error {
 	}
 
 	if existing {
-		return clone.Sync(target, clonePath, diag)
+		return clone.Sync(target, clonePath, p, diag)
 	}
 	return clone.Clone(target, clonePath, diag)
 }

--- a/main.go
+++ b/main.go
@@ -52,6 +52,20 @@ func run() error {
 	}
 
 	p := prompter.New(os.Stdin, os.Stdout, os.Stderr)
+
+	clonePath := getGhFolder() + "/" + repository.Owner + "/" + repository.Name
+	existing := clone.Exists(clonePath)
+	if existing {
+		update, err := p.Confirm(fmt.Sprintf("A clone already exists at %s. Update it?", clonePath), true)
+		if err != nil {
+			return err
+		}
+		if !update {
+			fmt.Fprintln(os.Stderr, "Aborting, existing clone left untouched.")
+			return nil
+		}
+	}
+
 	target, err := github.ResolveCloneTarget(repository.Owner, repository.Name, fork, client, p, diag)
 	if err != nil {
 		return err
@@ -62,7 +76,9 @@ func run() error {
 		fmt.Fprintf(diag, "Fork: %s/%s\n", target.Fork.Owner, target.Fork.Name)
 	}
 
-	clonePath := getGhFolder() + "/" + target.Repository.Owner + "/" + target.Repository.Name
+	if existing {
+		return clone.Sync(target, clonePath, diag)
+	}
 	return clone.Clone(target, clonePath, diag)
 }
 


### PR DESCRIPTION
Re-running `gh get` on a repository that's already cloned no longer fails with git's *"repository already exists"* error. Instead gh-get detects the existing clone and offers to update it.

## Behavior

- Existing clone detected → prompt **"A clone already exists at &lt;path&gt;. Update it?"** (default yes). Declining leaves the clone untouched and exits cleanly.
- On confirmation, gh-get fetches upstream and **fast-forwards** the current branch. A diverged branch or a dirty worktree is reported and skipped — local work is never clobbered.
- If the existing clone points `origin` at the original but a fork is now requested, the fork is created (via the existing resolve/fork flow) and remotes are reconfigured: `origin` → your fork, `upstream` → the original (reuses `setupForkRemotes`). A clone that already points at a fork is left alone.

## Implementation

- `internal/clone`: added `Exists` and `Sync`; extracted the token-auth block into `authMethod` (shared by `Clone` and `Sync`).
- `main.go`: checks for an existing clone before the fork decision, prompts, then routes to `Sync` vs `Clone`. Clone path is deterministic from the parsed repo, so detection is independent of the fork choice.

## Tests

- New `internal/clone/clone_test.go`: `Exists` detection, remote reconfiguration when a fork is requested, and that a fork-clone's remotes are left untouched. `go test ./...` passes.
- Integration tests (`integration-tests/tests.sh`) run non-interactively and the update prompt would block, so no case was added there. Verified manually instead.

Fixes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)